### PR TITLE
fixes #5 ensuring simultaneous turns

### DIFF
--- a/backend/src/card_game/api.clj
+++ b/backend/src/card_game/api.clj
@@ -5,29 +5,29 @@
 
 (defn player-num
   "Translates a Player id into an internal player representation"
-  [game id] (.indexOf (:player-ids game) id))
+  [game-state id] (.indexOf (:player-ids game-state) id))
 
 (defn translate-player
   "Translates an internal player to a useful representation"
-  [game internal me]
+  [game-state internal me]
   (cond
     (nil? internal) nil
     (>= internal 2) :tie
-    (= me (get-in game [:player-ids internal])) :me
+    (= me (get-in game-state [:player-ids internal])) :me
     :else :opponent))
 
 (defn get-game-as-player
   "Returns the part that ought to be visible to the player"
-  [game player]
-  {:game-id (:game-id game)
+  [game-state player]
+  {:game-id (:game-id game-state)
    :player-id player
-   :hand (get-in game [:players (player-num game player) :hand])
+   :hand (get-in game-state [:players (player-num game-state player) :hand])
    :rows (mapv #(mapv (fn [card]
                         (assoc card :owner
-                          (translate-player game (:owner card) player)))
+                          (translate-player game-state (:owner card) player)))
                       %)
-               (:rows game))
-   :winner (translate-player game (winner game) player)})
+               (:rows game-state))
+   :winner (translate-player game-state (winner game-state) player)})
 
 (defn get-game
   "Fetches a game from an ID and returns the visible part as a player"
@@ -36,10 +36,10 @@
 
 (defn play-card-as-player
   [game-id player index row]
-  (let [game (fetch-game game-id)]
-  (do
-    (save-game (play-card game (player-num game player) index row))
-    (get-game game-id player))))
+  (let [game-state (fetch-game game-id)]
+      (do
+        (save-game (play-card game-state (player-num game-state player) index row))
+        (get-game game-id player))))
 
 (defn uuid [] (str (java.util.UUID/randomUUID)))
 
@@ -56,12 +56,12 @@
   (let [saved-game (fetch-game game-id)]
     (if (> (count (:player-ids saved-game)) 1)
       {:error "Too many players"}
-      (let [game (save-game 
+      (let [game-state (save-game 
                    (create-player
                      (or 
                        saved-game 
                        (assoc (new-game) :game-id game-id))))]
-        (get-game-as-player game (last (:player-ids game)))))))
+        (get-game-as-player game-state (last (:player-ids game-state)))))))
 
 (defn create-game
   "Creates a new instance of a game"

--- a/backend/src/card_game/api.clj
+++ b/backend/src/card_game/api.clj
@@ -32,11 +32,9 @@
 (defn define-status
   "Returns the status of the game"
   [game-state player-id]
-  (nth ["Waiting for an opponent"
-       (if (get-in game-state [:play-wanted (player-num game-state player-id)])
-           "Playing"
-           "Waiting for opponent's play"
-            )] (dec(count (:player-ids game-state)))))
+  (cond (= (count (:player-ids game-state)) 1) "Waiting for an opponent"
+        (get-in game-state [:play-wanted (player-num game-state player-id)]) "Playing"
+        :else "Waiting for opponent's play"))
 
 (defn get-game
   "Fetches a game from an ID and returns the visible part as a player"

--- a/backend/src/card_game/api.clj
+++ b/backend/src/card_game/api.clj
@@ -32,7 +32,9 @@
 (defn get-game
   "Fetches a game from an ID and returns the visible part as a player"
   [id player]
-  (get-game-as-player (fetch-game id) player))
+  (let [saved-game (fetch-game id)]
+  (assoc (get-game-as-player saved-game player)
+         :status (nth ["Waiting for Opponent" "Playing"] (dec(count (:player-ids saved-game)))))))
 
 (defn play-card-as-player
   [game-id player index row]
@@ -53,15 +55,16 @@
 (defn add-player
   "Adds a player to a game"
   [game-id] 
-  (let [saved-game (fetch-game game-id)]
-    (if (> (count (:player-ids saved-game)) 1)
+  (let [saved-game (fetch-game game-id)
+        players-connected (count (:player-ids saved-game))]
+    (if (> players-connected 1)
       {:error "Too many players"}
       (let [game-state (save-game 
                    (create-player
                      (or 
                        saved-game 
                        (assoc (new-game) :game-id game-id))))]
-        (get-game-as-player game-state (last (:player-ids game-state)))))))
+        (get-game game-id (last (:player-ids game-state)))))))
 
 (defn create-game
   "Creates a new instance of a game"

--- a/backend/src/card_game/core.clj
+++ b/backend/src/card_game/core.clj
@@ -22,6 +22,7 @@
    {
     :players (vec (repeat 2 (new-player cards)))
     :rows (vec (repeat 5 []))
+    :play-wanted [true true]
     }))
 
 (defn add-card-to-row
@@ -46,13 +47,22 @@
   [game-state player index]
   (modify-hand game-state player (item-remover index)))
 
+(defn update-play-wanted
+  "Change which players are expected to play"
+  [game-state player]
+  (assoc game-state :play-wanted [(or (not= player 0) (not (get-in game-state [:play-wanted 1]))) 
+                                  (or (not= player 1) (not (get-in game-state [:play-wanted 0])))]))
+
 (defn play-card
   "Plays a card from hand onto a game row"
   [game-state player index row]
-  (let [card (get-in game-state [:players player :hand index])]
-    (-> game-state
-        (add-card-to-row (assoc card :owner player) row)
-        (remove-card player index))))
+  (if (get-in game-state [:play-wanted player])
+      (let [card (get-in game-state [:players player :hand index])]
+        (-> game-state
+            (add-card-to-row (assoc card :owner player) row)
+            (remove-card player index)
+            (update-play-wanted player)))
+      {:error "Out of turn play"}))
 
 (defn alter-card
   "Alters a cards' values, merging the new values with existing ones"

--- a/backend/test/card_game/api_test.clj
+++ b/backend/test/card_game/api_test.clj
@@ -62,39 +62,50 @@
   (-> (create-game)
       :hand))
 
+; Cards are removed from hands upon being played
 (expect
   #(= 11 (count (:hand %)))
-  (let [game (create-game)]
+  (let [game (create-game)
+        opponent (add-player (:game-id game))]
+    (play-card-as-player (:game-id game) (:player-id opponent) 0 0)
     (play-card-as-player (:game-id game) (:player-id game) 0 0)))
 
+; Card is not removed if opponent has not yet played
 (expect
   #(= 12 (count (:hand %)))
   (let [game (create-game)
-        other (add-player (:game-id game))]
-    (do
-      (play-card-as-player (:game-id game) (:player-id game) 0 0)
-      (get-game (:game-id game) (:player-id other)))))
-
-(expect
-  #(= 11 (count (:hand %)))
-  (let [game (create-game)
-        other (add-player (:game-id game))]
+        opponent (add-player (:game-id game))]
     (do
       (play-card-as-player (:game-id game) (:player-id game) 0 0)
       (get-game (:game-id game) (:player-id game)))))
 
+; Fetching the game as a player returns one less card after a play
+(expect
+  #(= 11 (count (:hand %)))
+  (let [game (create-game)
+        opponent (add-player (:game-id game))]
+    (do
+      (play-card-as-player (:game-id game) (:player-id opponent) 0 0)
+      (play-card-as-player (:game-id game) (:player-id game) 0 0)
+      (get-game (:game-id game) (:player-id game)))))
+
+; card played is owned by self
 (expect
   #(= :me (get-in % [:rows 0 0 :owner]))
-  (let [game (create-game)]
-    (play-card-as-player (:game-id game) (:player-id game) 0 0)))
-
-(expect
-  #(= :opponent (get-in % [:rows 0 0 :owner]))
   (let [game (create-game)
-        other (add-player (:game-id game))]
+        opponent (add-player (:game-id game))]
     (do
-      (play-card-as-player (:game-id game) (:player-id game) 0 0)
-      (get-game (:game-id game) (:player-id other)))))
+      (play-card-as-player (:game-id game) (:player-id opponent) 1 1)
+      (play-card-as-player (:game-id game) (:player-id game) 0 0))))
+
+; opponent's card is owned by him
+(expect
+  #(= :opponent (get-in % [:rows 1 0 :owner]))
+  (let [game (create-game)
+        opponent (add-player (:game-id game))]
+    (do
+      (play-card-as-player (:game-id game) (:player-id opponent) 1 1)
+      (play-card-as-player (:game-id game) (:player-id game) 0 0))))
 
 (expect
   #(contains? % :player-id)

--- a/backend/test/card_game/api_test.clj
+++ b/backend/test/card_game/api_test.clj
@@ -137,5 +137,25 @@
   #(not (= (:player-id %) (:player-id (add-player (:game-id %)))))
   (create-game))
 
-
-
+; Game is Waiting for Opponent until two players had joined
+(expect
+  "Waiting for Opponent"
+  (:status (create-game)))
+(expect
+  "Playing"
+  (-> (create-game)
+      :game-id
+      (add-player)
+      :status))
+(expect
+  "Playing"
+  (let [game (create-game)]
+    (-> (:game-id game)
+        (add-player)
+        :game-id
+        (play-card-as-player (:player-id game) 0 0)
+        :status)))
+(expect
+  "Waiting for Opponent"
+  (let [game (create-game)]
+       (:status (get-game (:game-id game) (:player-id game)))))

--- a/backend/test/card_game/api_test.clj
+++ b/backend/test/card_game/api_test.clj
@@ -125,3 +125,6 @@
 (expect
   #(not (= (:player-id %) (:player-id (add-player (:game-id %)))))
   (create-game))
+
+
+

--- a/backend/test/card_game/api_test.clj
+++ b/backend/test/card_game/api_test.clj
@@ -1,7 +1,6 @@
 (ns card-game.api-test
   (:use expectations
-        card-game.api
-        card-game.persistence))
+        card-game.api))
 
 (expect
   #(contains? % :game-id)

--- a/backend/test/card_game/core_test.clj
+++ b/backend/test/card_game/core_test.clj
@@ -138,16 +138,22 @@
 
 ; Stores next-play
 (expect
-  [0 0 0]
+  {:player 0 :index 0 :row 0}
   (-> (new-game)
       (play-card 0 0 0)
-      :next-play))
+      (get-in [:next-play 0])))
 (expect
-  [1 2 3]
+  {:player 1 :index 2 :row 3}
   (-> (new-game)
       (play-card 0 0 0)
       (play-card 1 1 1)
       (play-card 1 2 3)
+      (get-in [:next-play 0])))
+(expect
+  [{:player 0 :index 0 :row 0} {:player 1 :index 1 :row 1}]
+  (-> (new-game)
+      (play-card 0 0 0)
+      (play-card 1 1 1)
       :next-play))
 
 ; Doesn't updates game-state until both players played a card

--- a/backend/test/card_game/core_test.clj
+++ b/backend/test/card_game/core_test.clj
@@ -40,9 +40,10 @@
       (get-points)))
 
 (expect
-  [[10 0] [0 0] [0 0] [0 0] [0 0]]
+  [[10 0] [0 10] [0 0] [0 0] [0 0]]
   (-> (new-game)
       (play-card 0 0 0)
+      (play-card 1 1 1)
       (get-points)))
 
 (expect
@@ -134,3 +135,30 @@
   (-> (new-game)
       (play-card 0 0 0)
       (play-card 0 0 0)))
+
+; Stores next-play
+(expect
+  [0 0 0]
+  (-> (new-game)
+      (play-card 0 0 0)
+      :next-play))
+(expect
+  [1 2 3]
+  (-> (new-game)
+      (play-card 0 0 0)
+      (play-card 1 1 1)
+      (play-card 1 2 3)
+      :next-play))
+
+; Doesn't updates game-state until both players played a card
+(expect
+  [[0 0] [0 0] [0 0] [0 0] [0 0]]
+  (-> (new-game)
+      (play-card 0 0 0)
+      (get-points)))
+
+
+
+
+
+

--- a/backend/test/card_game/core_test.clj
+++ b/backend/test/card_game/core_test.clj
@@ -87,3 +87,50 @@
       (play-card 0 0 0)
       (play-card 1 0 0)
       (winner)))
+
+; Game tracks correctly who still has to play
+(expect
+  [true true]
+  (-> (new-game)
+      :play-wanted))
+
+(expect
+  [false true]
+  (-> (new-game)
+      (play-card 0 0 0)
+      :play-wanted))
+
+(expect
+  [true false]
+  (-> (new-game)
+      (play-card 1 0 0)
+      :play-wanted))
+
+(expect
+  [true true]
+  (-> (new-game)
+      (play-card 0 0 0)
+      (play-card 1 0 0)
+      :play-wanted))
+
+(expect
+  [true true]
+  (-> (new-game)
+      (play-card 1 0 0)
+      (play-card 0 0 0)
+      :play-wanted))
+
+(expect
+  [false true]
+  (-> (new-game)
+      (play-card 1 0 0)
+      (play-card 0 0 0)
+      (play-card 0 0 0)
+      :play-wanted))
+
+; Can't play a card when you were not supposed to
+(expect
+  {:error "Out of turn play"}
+  (-> (new-game)
+      (play-card 0 0 0)
+      (play-card 0 0 0)))

--- a/backend/test/card_game/effects_test.clj
+++ b/backend/test/card_game/effects_test.clj
@@ -20,6 +20,7 @@
     (-> (new-game)
         (alter-card [:players 0 :hand 0] {:power 15})
         (play-card 0 0 0)
+        (play-card 1 1 1)
         :rows (get 0) (get 0))))
 (expect
   [10 10 10 10 10 10 10 10 10 10 10]
@@ -27,6 +28,7 @@
        (-> (new-game)
            (alter-card [:players 0 :hand 0] {:power 15})
            (play-card 0 0 0)
+           (play-card 1 1 1)
            :players
            (nth 0)
            :hand)))
@@ -37,5 +39,6 @@
   (in
     (-> (new-game)
         (play-card 0 0 0)
+        (play-card 1 1 1)
         (alter-card [:rows 0 0] {:power 25})
         :rows (get 0) (get 0))))

--- a/backend/test/card_game/hand_test.clj
+++ b/backend/test/card_game/hand_test.clj
@@ -42,11 +42,13 @@
       second))
 
 ; Playing a card does not affect other players' hand
-; Don't see how to do this test right now. Changed to adapt to new logic
 (expect
-  #(= (count (:hand %)) 11)
-  (-> (new-game)
-      (play-card 1 1 1)
-      (play-card 0 0 0)
-      :players
-      first))
+  [15 10 10 10 10 10 10 10 10 10 10]
+  (map :power
+       (-> (new-game)
+           (alter-card [:players 1 :hand 0] {:power 15})
+           (play-card 0 0 0)
+           (play-card 1 1 1)
+           :players
+           (nth 1)
+           :hand)))

--- a/backend/test/card_game/hand_test.clj
+++ b/backend/test/card_game/hand_test.clj
@@ -36,14 +36,17 @@
 (expect
   #(= (count (:hand %)) 11)
   (-> (new-game)
+      (play-card 0 2 1)
       (play-card 1 1 1)
       :players
       second))
 
 ; Playing a card does not affect other players' hand
+; Don't see how to do this test right now. Changed to adapt to new logic
 (expect
-  #(= (count (:hand %)) 12)
+  #(= (count (:hand %)) 11)
   (-> (new-game)
       (play-card 1 1 1)
+      (play-card 0 0 0)
       :players
       first))

--- a/backend/test/card_game/row_test.clj
+++ b/backend/test/card_game/row_test.clj
@@ -14,12 +14,14 @@
   (map #(:power (get % 0))
        (-> (new-game)
            (play-card 1 1 3)
+           (play-card 0 1 3)
            :rows)))
 (expect
-  [nil 10 nil nil nil]
+  [10 10 nil nil nil]
   (map #(:power (get % 0))
        (-> (new-game)
            (play-card 1 1 1)
+           (play-card 0 0 0)
            :rows)))
 
 ; Playing a card many times makes it appear that many times in the row
@@ -34,5 +36,6 @@
            (play-card 1 1 3)
            (play-card 0 0 0)
            (play-card 1 1 3)
+           (play-card 0 0 2)
            :rows
            (get 3))))

--- a/backend/test/card_game/row_test.clj
+++ b/backend/test/card_game/row_test.clj
@@ -28,8 +28,11 @@
   (map :power 
        (-> (new-game)
            (play-card 1 1 3)
+           (play-card 0 0 0)
            (play-card 1 1 3)
+           (play-card 0 0 0)
            (play-card 1 1 3)
+           (play-card 0 0 0)
            (play-card 1 1 3)
            :rows
            (get 3))))


### PR DESCRIPTION
`:status` added to the game-state retrieved by `get.game`
Cards are not effectively played until the two players issued their play
Players can't play another card until the turn had been resolved