### PR TITLE
Fix for #14: Make testcafe wait 20s before launching tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ services:
 
 script:
   - docker-compose build
-  - docker-compose up -d
   - docker-compose run backend lein test
   - docker-compose run frontend yarn test
+  - docker-compose run testcafe firefox /tests/test.js --app 'true' --app-init-delay 20000
 
 notifications:
   email:


### PR DESCRIPTION
Trick testcafe into waiting for frontend and backend to start up before testing.