### PR TITLE
changed :play-wanted for :next-play

### DIFF
--- a/backend/src/card_game/api.clj
+++ b/backend/src/card_game/api.clj
@@ -33,7 +33,7 @@
   "Returns the status of the game"
   [game-state player-id]
   (cond (= (count (:player-ids game-state)) 1) "Waiting for an opponent"
-        (get-in game-state [:play-wanted (player-num game-state player-id)]) "Playing"
+        (nil? (get-in game-state [:next-play (player-num game-state player-id)])) "Playing"
         :else "Waiting for opponent's play"))
 
 (defn get-game

--- a/backend/test/card_game/core_test.clj
+++ b/backend/test/card_game/core_test.clj
@@ -93,47 +93,6 @@
         (core/play-card 1 0 0)
         (victory-conditions/winner))))
 
-(defexpect track-player
-  ; Game tracks correctly who still has to play
-  (expect
-    [true true]
-    (-> (core/new-game)
-        :play-wanted))
-
-  (expect
-    [false true]
-    (-> (core/new-game)
-        (core/play-card 0 0 0)
-        :play-wanted))
-
-  (expect
-    [true false]
-    (-> (core/new-game)
-        (core/play-card 1 0 0)
-        :play-wanted))
-
-  (expect
-    [true true]
-    (-> (core/new-game)
-        (core/play-card 0 0 0)
-        (core/play-card 1 0 0)
-        :play-wanted))
-
-  (expect
-    [true true]
-    (-> (core/new-game)
-        (core/play-card 1 0 0)
-        (core/play-card 0 0 0)
-        :play-wanted))
-
-  (expect
-    [false true]
-    (-> (core/new-game)
-        (core/play-card 1 0 0)
-        (core/play-card 0 0 0)
-        (core/play-card 0 0 0)
-        :play-wanted)))
-
 (defexpect ot-of-turn
   ; Can't play a card when you were not supposed to
   (expect
@@ -155,13 +114,31 @@
         (core/play-card 0 0 0)
         (core/play-card 1 1 1)
         (core/play-card 1 2 3)
-        (get-in [:next-play 0])))
+        (get-in [:next-play 1])))
+  ; Stores nil when a play is expected
   (expect
-    [{:player 0 :index 0 :row 0} {:player 1 :index 1 :row 1}]
+    [nil nil]
     (-> (core/new-game)
         (core/play-card 0 0 0)
         (core/play-card 1 1 1)
-        :next-play)))
+        :next-play))
+  (expect
+    [nil nil]
+    (-> (core/new-game)
+        :next-play))
+  (expect
+    nil
+    (-> (core/new-game)
+        (core/play-card 0 0 0)
+        (get-in [:next-play 1])))
+  (expect
+    nil
+    (-> (core/new-game)
+        (core/play-card 0 0 0)
+        (core/play-card 1 1 1)
+        (core/play-card 1 2 3)
+        (get-in [:next-play 0]))))
+
 
 (defexpect update-only-when-both-play
   ; Doesn't updates game-state until both players played a card


### PR DESCRIPTION
Will avoid unnecessary keys.
Also, it could be useful in the future to have each `:next-play` stored in a different place for each player (rather than like if it were a queue)
I haven't changed the keys of a play (even though now it's redundant to have `:player`) since they are still to be studied when more cards appear.