### PR TITLE
API tests: persistence mocked, some refactoring

### DIFF
--- a/backend/src/configs/messages.clj
+++ b/backend/src/configs/messages.clj
@@ -2,7 +2,7 @@
   (:require [yaml.core :as yaml]))
 
 (def ^:private config-file
-  (yaml/from-file "/configs/config.yml" true))
+  (yaml/from-file "../configs/config.yml" true))
 
 (def out-of-turn (get-in config-file [:messages :out-of-turn]))
 

--- a/backend/test/api/messages_test.clj
+++ b/backend/test/api/messages_test.clj
@@ -1,23 +1,31 @@
 (ns api.messages-test
   (:require [expectations.clojure.test :refer :all]
+            [clojure.test :as ctest]
+            [mocking :as mocking]
             [api.base :as api]
             [configs.messages :as messages]))
 
-(defexpect status-check
-  ; Game tracks status correctly
-  (expect
-    messages/no-opp
-    (:status (api/create-game)))
+(ctest/use-fixtures :each mocking/mock-persistence)
+
+(defexpect no-opp-on-creation
+  (let [game (api/create-game)]
+    (expect
+      messages/no-opp
+      (:status game))
+    (expect
+      messages/no-opp
+      (:status
+        (api/get-game (:game-id game) (:player-id game))))))
+
+(defexpect play-on-both-players
   (expect
     messages/play
     (-> (api/create-game)
         :game-id
         (api/add-player)
-        :status))
-  (expect
-    messages/no-opp
-    (let [game (api/create-game)]
-      (:status (api/get-game (:game-id game) (:player-id game)))))
+        :status)))
+
+(defexpect wait-on-card-played
   (expect
     messages/wait
     (let [game (api/create-game)
@@ -25,42 +33,39 @@
           player-id (:player-id game)]
       (do (api/add-player game-id)
           (:status
-            (api/play-card-as-player game-id player-id 0 0)))))
- 
-  (expect
-    messages/play
-    (let [game (api/create-game)
-          game-id (:game-id game)
-          player-id (:player-id game)
-          opponent-id (:player-id (api/add-player game-id))]
+            (api/play-card-as-player game-id player-id 0 0))))))
+
+(defexpect play-on-not-played
+  (let [game (api/create-game)
+        game-id (:game-id game)
+        player-id (:player-id game)
+        opponent-id (:player-id (api/add-player game-id))]
+    (expect
+      messages/play
       (do (api/play-card-as-player game-id player-id 0 0)
           (:status
-            (api/play-card-as-player game-id opponent-id 0 0)))))
- 
-  (expect
-    messages/play
-    (let [game (api/create-game)
-          game-id (:game-id game)
-          player-id (:player-id game)
-          opponent-id (:player-id (api/add-player game-id))]
+            (api/play-card-as-player game-id opponent-id 0 0))))
+
+    (expect
+      messages/play
       (do (api/play-card-as-player game-id opponent-id 0 0)
           (:status
-            (api/get-game game-id player-id)))))) 
+            (api/get-game game-id player-id))))))
 
 (defexpect out-of-turn
   ; Game gives error when playing and shouldn't
-  (expect
-    {:error messages/out-of-turn}
-    (let [game (api/create-game)
-          game-id (:game-id game)
-          player-id (:player-id game)]
+  (let [game (api/create-game)
+        game-id (:game-id game)
+        player-id (:player-id game)]
+
+    (expect
+      {:error messages/out-of-turn}
+      (api/play-card-as-player game-id player-id 0 0))
+
+    (expect
+      {:error messages/out-of-turn}
       (do (api/add-player game-id)
           (api/play-card-as-player game-id player-id 0 0)
-          (api/play-card-as-player game-id player-id 0 0))))
-  
-  (expect
-    {:error messages/out-of-turn}
-    (let [game (api/create-game)
-          game-id (:game-id game)
-          player-id (:player-id game)]
-      (api/play-card-as-player game-id player-id 0 0))))      
+          (api/play-card-as-player game-id player-id 0 0)))))
+
+

--- a/backend/test/api/newgame_test.clj
+++ b/backend/test/api/newgame_test.clj
@@ -1,50 +1,48 @@
 (ns api.newgame-test
   (:require [expectations.clojure.test :refer :all]
+            [clojure.test :as ctest]
+            [mocking :as mocking]
             [api.base :as api]
             [configs.hands :as hands]
             [configs.messages :as messages]))
 
+(ctest/use-fixtures :each mocking/mock-persistence)
+
 (defexpect sanity-check
-  (expect
-    #(contains? % :game-id)
-    (api/create-game))
-  (expect
-    #(contains? % :player-id)
-    (api/create-game))
-  (expect
-    #(= (count (:hand %)) (count hands/default-hand))
-    (api/create-game))
-  (expect
-    #(= 5 (count (:rows %)))
-    (api/create-game)))
+  (let [game (api/create-game)]
+    (expect
+      #(contains? % :game-id)
+      game)
+    (expect
+      #(contains? % :player-id)
+      game)
+    (expect
+      #(= (count (:hand %)) (count hands/default-hand))
+      game)
+    (expect
+      #(= 5 (count (:rows %)))
+      game)))
 
 (defexpect joining-a-game
-  (expect
-    #(contains? % :player-id)
-    (-> (api/create-game)
-        :game-id
-        (api/add-player)))
+  (let [game (api/create-game)
+        opponent (api/add-player (:game-id game))]
+    (expect
+      #(contains? % :player-id)
+      opponent)
 
-  (expect
-    #(not (contains? % :error))
-    (-> (api/create-game)
-        :game-id
-        (api/add-player)))
+    (expect
+      #(not (contains? % :error))
+      opponent)
 
-  (expect
-    #(= % (:game-id (api/add-player %)))
-    (-> (api/create-game)
-        :game-id))
+    (expect
+      true
+      (= (:game-id game) (:game-id opponent)))
 
-  ; A third player causes an error
-  (expect
-    {:error messages/too-many-players}
-    (-> (api/create-game)
-        :game-id
-        (api/add-player)
-        :game-id
-        (api/add-player)))
+    ; A third player causes an error
+    (expect
+      {:error messages/too-many-players}
+      (api/add-player (:game-id game)))
 
-  (expect
-    #(not (= (:player-id %) (:player-id (api/add-player (:game-id %)))))
-    (api/create-game)))
+    (expect
+      false
+      (= (:player-id game) (:player-id opponent)))))

--- a/backend/test/api/scores_test.clj
+++ b/backend/test/api/scores_test.clj
@@ -1,9 +1,13 @@
 (ns api.scores-test
   (:require [expectations.clojure.test :refer :all]
+            [clojure.test :as ctest]
+            [mocking :as mocking]
             [api.base :as api]
             [test-hand :as hand]
             [autoplay :as autoplay]
             [configs.hands :as hands]))
+
+(ctest/use-fixtures :each mocking/mock-persistence)
 
 (defexpect rows-won
   (expect
@@ -12,45 +16,44 @@
     (autoplay/as-api
       (fn [i] (mod i 4))
       (fn [i] 0)))
-  (expect
-    #(= [2 2]
-        (:scores %))
-    (autoplay/as-api
-      (fn [i] (mod i 2))
-      (fn [i] (+ (mod i 2) 2)))))
+
+  (defexpect rows-tied
+    (expect
+      #(= [2 2]
+          (:scores %))
+      (autoplay/as-api
+        (fn [i] (mod i 2))
+        (fn [i] (+ (mod i 2) 2))))))
 
 (defexpect power-in-rows
-  ; Game begins with scores at 0
-  (expect
-    [[0 0] [0 0] [0 0] [0 0] [0 0]]
-    (let [game-state (api/create-game)
-          game-id (:game-id game-state)
-          player-id (:player-id game-state)
-          opponent-id (:player-id (api/add-player game-id))]
-      (:rows-power (api/get-game game-id player-id))))
-  (expect
-    [[(hand/power-of-nth 0) (hand/power-of-nth 1)]
-     [0 0] [0 0] [0 0] [0 0]]
-    (let [game-state (api/create-game)
-          game-id (:game-id game-state)
-          player-id (:player-id game-state)
-          opponent-id (:player-id (api/add-player game-id))]
+  (let [game-state (api/create-game)
+        game-id (:game-id game-state)
+        player-id (:player-id game-state)
+        opponent-id (:player-id (api/add-player game-id))]
+
+    ; Game begins with scores at 0
+    (expect
+      [[0 0] [0 0] [0 0] [0 0] [0 0]]
+      (:rows-power (api/get-game game-id player-id)))
+
+    ; Play on same row
+    (expect
+      [[(hand/power-of-nth 0) (hand/power-of-nth 1)]
+       [0 0] [0 0] [0 0] [0 0]]
       (do
         (api/play-card-as-player game-id player-id 0 0)
-        (api/play-card-as-player game-id opponent-id 1 0))
-      (:rows-power (api/get-game game-id player-id))))
-  (expect
-    [[0 (+ (hand/power-of-nth 0) (hand/power-of-nth 1))]
-     [(hand/power-of-nth 0) 0]
-     [(hand/power-of-nth 1) 0]
-     [0 0] [0 0]]
-    (let [game-state (api/create-game)
-          game-id (:game-id game-state)
-          player-id (:player-id game-state)
-          opponent-id (:player-id (api/add-player game-id))]
+        (api/play-card-as-player game-id opponent-id 1 0)
+        (:rows-power (api/get-game game-id player-id))))
+
+    ; Play on different rows
+    (expect
+      [[
+        (+ (hand/power-of-nth 0) (hand/power-of-nth 1))
+        (hand/power-of-nth 0)]
+       [0 0]
+       [0 (hand/power-of-nth 1)]
+       [0 0] [0 0]]
       (do
-        (api/play-card-as-player game-id player-id 0 0)
-        (api/play-card-as-player game-id opponent-id 0 1)
-        (api/play-card-as-player game-id player-id 0 0)
-        (api/play-card-as-player game-id opponent-id 0 2)
-      (:rows-power (api/get-game game-id opponent-id))))))
+        (api/play-card-as-player game-id player-id 0 2)
+        (api/play-card-as-player game-id opponent-id 0 0)
+        (:rows-power (api/get-game game-id opponent-id))))))

--- a/backend/test/api/winner_test.clj
+++ b/backend/test/api/winner_test.clj
@@ -1,22 +1,28 @@
 (ns api.winner-test
   (:require [expectations.clojure.test :refer :all]
+            [clojure.test :as ctest]
+            [mocking :as mocking]
             [autoplay :as autoplay]))
 
-(defexpect win-conditions
+(ctest/use-fixtures :each mocking/mock-persistence)
+
+(defexpect tie
   ; Both stack all cards on one row -> tie
   (expect
     #(= :tie (:winner %))
     (autoplay/as-api
       (fn [i] 0)
-      (fn [i] 0)))
+      (fn [i] 0))))
 
+(defexpect i-win
   ; Opponent stacks all cards on one row and I spread -> I win
   (expect
     #(= :me (:winner %))
     (autoplay/as-api
       (fn [i] (mod i 4))
-      (fn [i] 0)))
+      (fn [i] 0))))
 
+(defexpect i-lose
   ; I stack all cards on one row and opponent spreads -> Opponent wins
   (expect
     #(= :opponent (:winner %))

--- a/backend/test/mocking.clj
+++ b/backend/test/mocking.clj
@@ -1,0 +1,15 @@
+(ns mocking
+  (:require [persistence.persistence :as persistence]))
+
+(def mock-game (atom nil))
+
+(defn mock-persistence
+  [tests]
+    (with-redefs
+      [persistence/next-id (constantly 0)
+       persistence/save-game (fn [a]
+                               (reset! mock-game a))
+       persistence/fetch-game (fn [x] 
+                                @mock-game)]
+      (tests))
+    (reset! mock-game nil))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
             - "3000:3000"
         volumes:
             - ./backend:/usr/src/app
-            - ./configs:/configs
+            - ./configs:/usr/src/configs
             - lein-deps:/root/.m2
         links:
             - redis


### PR DESCRIPTION
More stuff for #80.

As a bonus, it is now possible to run `lein test` and `lein test-refresh` locally within the `backend` folder, without need of docker, due to all calls to persistence being mocked in tests.