### PR TITLE
Limit can be configured

### DIFF
--- a/backend/src/api/base.clj
+++ b/backend/src/api/base.clj
@@ -13,11 +13,11 @@
   (player-view/get-game-as-player (persistence/fetch-game game-id) player-id))
 
 (defn play-card-as-player
-  [game-id player index row & target]
+  [game-id player index row-id & target]
   (let [game-state (persistence/fetch-game game-id)]
       (if (= (:status (get-game game-id player)) messages/play)
           (do
-            (persistence/save-game (play-card/play-card game-state (conversions/player-num game-state player) index row (first target)))
+            (persistence/save-game (play-card/play-card game-state (conversions/player-num game-state player) index row-id (first target)))
             (get-game game-id player))
           {:error messages/out-of-turn})))
 

--- a/backend/src/api/player_view_functions.clj
+++ b/backend/src/api/player_view_functions.clj
@@ -8,13 +8,19 @@
   [game-state player-id]
   (get-in game-state [:players (conversions/player-num game-state player-id) :hand]))
 
+(defn get-row-cards
+  "Returns the cards as seen by the player"
+  [row-cards game-state player-id]
+  (mapv (fn [card]
+          (assoc card :owner
+                 (conversions/translate-player game-state (:owner card) player-id)))
+        row-cards))
+
 (defn get-rows
   "Return the rows as seen by the player"
   [game-state player-id]
-  (mapv #(mapv (fn [card]
-                 (assoc card :owner
-                   (conversions/translate-player game-state (:owner card) player-id)))
-               %)
+  (mapv (fn [row]
+          (get-row-cards (:cards row) game-state player-id))
         (:rows game-state)))
 
 (defn get-rows-power
@@ -28,8 +34,8 @@
         rows-power
         (recur
           (conj rows-power
-                [(victory/points-in-row (first rows) player)
-                 (victory/points-in-row (first rows) opponent)])
+                [(victory/points-in-row (:cards (first rows)) player)
+                 (victory/points-in-row (:cards (first rows)) opponent)])
           (rest rows))))))
 
 (defn get-scores

--- a/backend/src/configs/rows.clj
+++ b/backend/src/configs/rows.clj
@@ -1,0 +1,3 @@
+(ns configs.rows)
+
+(def default-limit 4)

--- a/backend/src/rules/create_game.clj
+++ b/backend/src/rules/create_game.clj
@@ -1,5 +1,6 @@
 (ns rules.create-game
-  (:require [configs.hands :as hands]))
+  (:require [configs.hands :as hands]
+            [configs.rows :as rows]))
 
 (defn ^:private new-player
   "Creates a new player object"
@@ -17,6 +18,9 @@
     :players (vec (repeat 2 (new-player (if (contains? ini-config :hand)
                                             (:hand ini-config)
                                             hands/default-hand))))
-    :rows (vec (repeat 5 []))
+    :rows (vec (repeat 5 {:limit (if (contains? ini-config :limit)
+                                     (:limit ini-config)
+                                     rows/default-limit)
+                          :cards []}))
     :next-play [nil nil]
     }))

--- a/backend/src/rules/play_card.clj
+++ b/backend/src/rules/play_card.clj
@@ -3,8 +3,8 @@
 
 (defn ^:private add-card-to-row
   "Adds a card onto the specified row"
-  [game-state card row]
-  (update-in game-state [:rows row] #(conj % card)))
+  [game-state card row-id]
+  (update-in game-state [:rows row-id :cards] #(conj % card)))
 
 (defn ^:private modify-hand
   "Modifies a player's hand according to some function"
@@ -28,10 +28,10 @@
   [game-state play]
     (let [player (:player play)
           index (:index play)
-          row (:row play)
+          row-id (:row play)
           card (get-in game-state [:players player :hand index])]
       (-> game-state
-          (add-card-to-row (assoc card :owner player) row)
+          (add-card-to-row (assoc card :owner player) row-id)
           (remove-card player index))))
 
 (defn ^:private apply-all-plays
@@ -44,12 +44,12 @@
 
 (defn play-card
   "Takes a playing of a card from hand onto a game row and makes it wait until both players had played"
-  [game-state player index row & target]
+  [game-state player index row-id & target]
   ; Uses stored :next-play to know who is supposed to play
   (if (nil? (get-in game-state [:next-play player]))
       (if (every? nil? (:next-play game-state))
-          (assoc-in game-state [:next-play player] {:player player :index index :row row :target (first target)})
+          (assoc-in game-state [:next-play player] {:player player :index index :row row-id :target (first target)})
           (-> game-state
-              (assoc-in [:next-play player] {:player player :index index :row row :target (first target)})
+              (assoc-in [:next-play player] {:player player :index index :row row-id :target (first target)})
               (apply-all-plays)))
       {:error messages/out-of-turn}))

--- a/backend/src/rules/victory_conditions.clj
+++ b/backend/src/rules/victory_conditions.clj
@@ -8,21 +8,21 @@
     (= 0 (count (get-in game-state [:players 1 :hand])))))
 
 (defn points-in-row
-  "Tells us how many points the data of a row has for a certain player"
-  [row-data player]
+  "Tells us how many points the cards of a row has for a certain player"
+  [row-cards player]
   (reduce
     #(if (= (:owner %2) player)
        (+ %1 (:power %2))
        %1)
     0
-    row-data))
+    row-cards))
 
 (defn ^:private player-wins-row?
   "Tells us if a player is winning a row from its data"
   [row-data player]
   (let [opponent (mod (inc player) 2)]
-    (> (points-in-row row-data player)
-       (points-in-row row-data opponent))))
+    (> (points-in-row (:cards row-data) player)
+       (points-in-row (:cards row-data) opponent))))
 
 (defn get-won-rows
   "Tells us how many rows a player is winning"

--- a/backend/test/rules/new_game_test.clj
+++ b/backend/test/rules/new_game_test.clj
@@ -4,6 +4,7 @@
             [rules.play-card :as play-card]
             [rules.victory-conditions :as victory]
             [configs.hands :as hands]
+            [configs.rows :as rows]
             [autoplay :as autoplay]))
 
 (defexpect basic.game
@@ -24,9 +25,9 @@
         (get-in [:players 0 :hand])
         (empty?)))
 
-  ; Rows begin empty
+  ; Rows begin empty and with limit
   (expect
-    (repeat 5 [])
+    (repeat 5 {:limit rows/default-limit :cards []})
     (-> (create-game/new-game)
         :rows)))
 

--- a/backend/test/rules/play/hand_to_row.clj
+++ b/backend/test/rules/play/hand_to_row.clj
@@ -2,23 +2,27 @@
   (:require [expectations.clojure.test :refer :all]
             [rules.play-card :as play-card]))
 
+(def empty-rows
+  [{:cards []} {:cards []}])
+
 (defexpect move-card
   ; Playing a card makes the card dissappear from the hand
   (expect
     [{:hand []} {:hand [{:blep "S"}]}]
     (-> {:players [{:hand [{}]}
                    {:hand [{:blep "S"} {}]}]
-         :rows [[] []]}
+         :rows empty-rows}
         (play-card/play-card 0 0 1)
         (play-card/play-card 1 1 0)
         :players))
 
   ; Playing a card makes the card appear in play with an owner
   (expect
-    [[{:blep "S" :owner 1}] [{:boop 1 :owner 0}]]
+    [{:cards [{:blep "S" :owner 1}]} 
+     {:cards [{:boop 1 :owner 0}]}]
     (-> {:players [{:hand [{:boop 1}]}
                    {:hand [{} {:blep "S"}]}]
-         :rows [[] []]}
+         :rows empty-rows}
         (play-card/play-card 0 0 1)
         (play-card/play-card 1 1 0)
         :rows)))

--- a/backend/test/rules/play/next_play.clj
+++ b/backend/test/rules/play/next_play.clj
@@ -2,18 +2,21 @@
   (:require [expectations.clojure.test :refer :all]
             [rules.play-card :as play-card]))
 
+(def empty-rows
+  [{:cards []} {:cards []} {:cards []}])
+
 (defexpect next-play
   ; Stores next-play
   (expect
     {:player 0 :index 0 :row 0 :target nil}
     (-> {:players [{:hand [{} {}]} {:hand [{} {}]}]
-         :rows [[]]}
+         :rows empty-rows}
         (play-card/play-card 0 0 0)
         (get-in [:next-play 0])))
   (expect
     {:player 1 :index 2 :row 3 :target nil}
     (-> {:players [{:hand [{} {}]} {:hand [{} {} {}]}]
-         :rows [[] [] []]}
+         :rows empty-rows}
         (play-card/play-card 0 0 0)
         (play-card/play-card 1 1 1)
         (play-card/play-card 1 2 3)
@@ -22,20 +25,20 @@
   (expect
     [nil nil]
     (-> {:players [{:hand [{} {}]} {:hand [{} {}]}]
-         :rows [[]]}
+         :rows empty-rows}
         (play-card/play-card 0 0 0)
         (play-card/play-card 1 1 1)
         :next-play))
   (expect
     nil
     (-> {:players [{:hand [{} {}]} {:hand [{} {}]}]
-         :rows [[]]}
+         :rows empty-rows}
         (play-card/play-card 0 0 0)
         (get-in [:next-play 1])))
   (expect
     nil
     (-> {:players [{:hand [{} {}]} {:hand [{} {} {}]}]
-         :rows [[] [] []]}
+         :rows empty-rows}
         (play-card/play-card 0 0 0)
         (play-card/play-card 1 1 1)
         (play-card/play-card 1 2 3)
@@ -44,8 +47,8 @@
 (defexpect update-only-when-both-play
   ; Doesn't updates game-state until both players played a card
   (expect
-    [[]]
+    empty-rows
     (-> {:players [{:hand [{}]} {:hand []}]
-         :rows [[]]}
+         :rows empty-rows}
         (play-card/play-card 0 0 0)
         :rows)))

--- a/backend/test/rules/row_winner_test.clj
+++ b/backend/test/rules/row_winner_test.clj
@@ -5,20 +5,28 @@
 (defexpect row-winner
   (expect
     0
-    (victory/get-won-rows {:rows [[] [] [] [] []]} 0))
+    (victory/get-won-rows {:rows [{:cards []} 
+                                  {:cards []} 
+                                  {:cards []} 
+                                  {:cards []}
+                                  {:cards []}]} 0))
 
   (expect
     1
-    (victory/get-won-rows {:rows [[{:power 1 :owner 5}] [] [] [] []]} 5))
+    (victory/get-won-rows {:rows [{:cards [{:power 1 :owner 5}]}
+                                  {:cards []} 
+                                  {:cards []}
+                                  {:cards []}
+                                  {:cards []}]} 5))
 
   (expect
     4
     (victory/get-won-rows
       {:rows [
-              [{:power 1 :owner 0}]
-              [{:power 200 :owner 1} {:power 9001 :owner 0}]
-              [{:power -1 :owner 0} {:power 5 :owner 1} {:power 9 :owner 0}]
-              [{:power 3 :owner 1} {:power 1 :owner 0}
-               {:power 2 :owner 0} {:power -1 :owner 1}]
+              {:cards [{:power 1 :owner 0}]}
+              {:cards [{:power 200 :owner 1} {:power 9001 :owner 0}]}
+              {:cards [{:power -1 :owner 0} {:power 5 :owner 1} {:power 9 :owner 0}]}
+              {:cards [{:power 3 :owner 1} {:power 1 :owner 0}
+                       {:power 2 :owner 0} {:power -1 :owner 1}]}
               []]}
       0)))

--- a/backend/test/rules/winner_test.clj
+++ b/backend/test/rules/winner_test.clj
@@ -37,20 +37,20 @@
     0
     (victory/winner
       {:players [{:hand []} {:hand[]}]
-       :rows [[{:power 1 :owner 0}]]}))
+       :rows [{:cards [{:power 1 :owner 0}]}]}))
   (expect
     1
     (victory/winner
       {:players [{:hand []} {:hand[]}]
        :rows [
-              [{:power 20 :owner 0}]
-              [{:power 1 :owner 1}]
-              [{:power 5 :owner 0} {:power 6 :owner 1}]]}))
+              {:cards [{:power 20 :owner 0}]}
+              {:cards [{:power 1 :owner 1}]}
+              {:cards [{:power 5 :owner 0} {:power 6 :owner 1}]}]}))
   (expect
     2
     (victory/winner
       {:players [{:hand []} {:hand[]}]
        :rows [
-              [{:power 20 :owner 0}]
-              [{:power 1 :owner 1}]
-              [{:power 5 :owner 0} {:power 5 :owner 1}]]})))
+              {:cards [{:power 20 :owner 0}]}
+              {:cards [{:power 1 :owner 1}]}
+              {:cards [{:power 5 :owner 0} {:power 5 :owner 1}]}]})))


### PR DESCRIPTION
This solves #88.

It required changing the structure of `:rows` and adapting the backend tests for it. 

Right now limit configured is used for nothing, and the rows are passed to frontend in the same format as before.