### PR TITLE
Add-Power on Backend

### DIFF
--- a/backend/src/api/base.clj
+++ b/backend/src/api/base.clj
@@ -23,8 +23,7 @@
 
 (defn add-player
   "Adds a player to a game"
-  ([game-id] (add-player game-id {}))
-  ([game-id ini-config]
+  [game-id & ini-config]
   (let [saved-game (persistence/fetch-game game-id)
         players-connected (count (:player-ids saved-game))]
     (if (> players-connected 1)
@@ -33,10 +32,10 @@
                    (generators/player-uuid
                      (or
                        saved-game
-                       (assoc (create-game/new-game ini-config) :game-id game-id))))]
-        (get-game game-id (last (:player-ids game-state))))))))
+                       (assoc (create-game/new-game (first ini-config)) :game-id game-id))))]
+        (get-game game-id (last (:player-ids game-state)))))))
 
 (defn create-game
   "Creates a new instance of a game"
-  ([] (create-game {}))
-  ([ini-config] (add-player (persistence/next-id) ini-config)))
+  [& ini-config]
+  (add-player (persistence/next-id) (first ini-config)))

--- a/backend/src/api/player_view_functions.clj
+++ b/backend/src/api/player_view_functions.clj
@@ -20,7 +20,9 @@
   "Return the rows as seen by the player"
   [game-state player-id]
   (mapv (fn [row]
-          (get-row-cards (:cards row) game-state player-id))
+          (assoc row
+                 :cards
+                 (get-row-cards (:cards row) game-state player-id)))
         (:rows game-state)))
 
 (defn get-rows-power

--- a/backend/src/rules/create_game.clj
+++ b/backend/src/rules/create_game.clj
@@ -11,13 +11,12 @@
 
 (defn new-game
   "Creates a new game object"
-  ([] (new-game {}))
-  ([ini-config]
-   {
-    :players (vec (repeat 2 (new-player (:hand ini-config hands/default-hand))))
+  [& ini-config]
+  {
+    :players (vec (repeat 2 (new-player (:hand (first ini-config) hands/default-hand))))
     :rows (vec (reduce
                  #(concat %1 [{:limit %2 :cards []}])
                  []
-                 (:limits ini-config rows/default-limits)))
+                 (:limits (first ini-config) rows/default-limits)))
     :next-play [nil nil]
-    }))
+  })

--- a/backend/src/rules/create_game.clj
+++ b/backend/src/rules/create_game.clj
@@ -11,12 +11,13 @@
 
 (defn new-game
   "Creates a new game object"
-  [& ini-config]
-  {
-    :players (vec (repeat 2 (new-player (:hand (first ini-config) hands/default-hand))))
-    :rows (vec (reduce
-                 #(concat %1 [{:limit %2 :cards []}])
-                 []
-                 (:limits (first ini-config) rows/default-limits)))
-    :next-play [nil nil]
-  })
+  ([] (new-game {}))
+  ([ini-config]
+   {
+     :players (vec (repeat 2 (new-player (:hand ini-config hands/default-hand))))
+     :rows (vec (reduce
+                  #(concat %1 [{:limit %2 :cards []}])
+                  []
+                  (:limits ini-config rows/default-limits)))
+     :next-play [nil nil]
+   }))

--- a/backend/src/rules/create_game.clj
+++ b/backend/src/rules/create_game.clj
@@ -14,10 +14,10 @@
   ([] (new-game {}))
   ([ini-config]
    {
-     :players (vec (repeat 2 (new-player (:hand ini-config hands/default-hand))))
-     :rows (vec (reduce
-                  #(concat %1 [{:limit %2 :cards []}])
-                  []
-                  (:limits ini-config rows/default-limits)))
-     :next-play [nil nil]
+    :players (vec (repeat 2 (new-player (:hand ini-config hands/default-hand))))
+    :rows (vec (reduce
+                 #(concat %1 [{:limit %2 :cards []}])
+                 []
+                 (:limits ini-config rows/default-limits)))
+    :next-play [nil nil]
    }))

--- a/backend/test/api/effects_test.clj
+++ b/backend/test/api/effects_test.clj
@@ -1,0 +1,23 @@
+(ns api.effects-test
+  (:require [expectations.clojure.test :refer :all]
+            [clojure.test :as ctest]
+            [mocking :as mocking]
+            [api.base :as api]))
+
+(ctest/use-fixtures :each mocking/mock-persistence)
+
+(defexpect playing-effects
+  ; Can play cards with effects and they act as expected
+  (expect
+    -100
+    (let [game (api/create-game {:hand [{:power 0} {:power 10 :add-power -100} {:power 10}]})
+          game-id (:game-id game)
+          player-id (:player-id game)
+          opponent-id (:player-id (api/add-player game-id))]
+      (api/play-card-as-player game-id player-id   0 0)
+      (api/play-card-as-player game-id opponent-id 0 1)
+      (api/play-card-as-player game-id player-id   1 1)
+      (println (api/get-game game-id player-id))
+      (api/play-card-as-player game-id opponent-id 0 1 [:rows 0 :cards 0])
+      (get-in (api/get-game game-id player-id)
+              [:rows 0 :cards 0 :power]))))

--- a/backend/test/api/play_test.clj
+++ b/backend/test/api/play_test.clj
@@ -32,10 +32,10 @@
 
     ; card played is owned by self
     (expect
-      #(= :me (get-in % [:rows 0 0 :owner]))
+      #(= :me (get-in % [:rows 0 :cards 0 :owner]))
       (api/get-game game-id player-id))
 
     ; opponent's card is owned by him
     (expect
-      #(= :opponent (get-in % [:rows 1 0 :owner]))
+      #(= :opponent (get-in % [:rows 1 :cards 0 :owner]))
       (api/get-game game-id player-id))))

--- a/backend/test/rules/effects_test.clj
+++ b/backend/test/rules/effects_test.clj
@@ -42,4 +42,12 @@
     (-> (play-card/apply-play-card {:rows [{:cards [{:power 24}]}]
                                     :players [{:hand [{:add-power 18}]}]}
                                    {:player 0 :index 0 :row 0 :target [:rows 0 :cards 0]})
-        (get-in [:rows 0 :cards 0 :power]))))
+        (get-in [:rows 0 :cards 0 :power])))
+  (expect
+    {:power -2 :coolness 100}
+    (-> (play-card/apply-play-card {:rows [{}{:cards [{:power 4 :coolness 100}]}]
+                                    :players [{:hand [{:add-power -6}]}]}
+                                   {:player 0 :index 0 :row 0 :target [:rows 1 :cards 0]})
+       (get-in [:rows 1 :cards 0])))) 
+
+

--- a/backend/test/rules/effects_test.clj
+++ b/backend/test/rules/effects_test.clj
@@ -1,6 +1,7 @@
 (ns rules.effects-test
   (:require [expectations.clojure.test :refer :all]
-            [rules.alter-card :as alter-card]))
+            [rules.alter-card :as alter-card]
+            [rules.play-card :as play-card]))
 
 (defexpect card-altering
   (expect
@@ -33,3 +34,12 @@
       [nil {:croissant "chocolate" :enchilada {:power 1 :salsa "mild"}}]
       [1 :enchilada]
       55)))
+
+(defexpect playing-add-power
+  ; Cards that should add power do so
+  (expect
+    42
+    (-> (play-card/apply-play-card {:rows [{:cards [{:power 24}]}]
+                                    :players [{:hand [{:add-power 18}]}]}
+                                   {:player 0 :index 0 :row 0 :target [:rows 0 :cards 0]})
+        (get-in [:rows 0 :cards 0 :power]))))

--- a/frontend/src/game/board/board.js
+++ b/frontend/src/game/board/board.js
@@ -19,7 +19,7 @@ module.exports = {
         })
 
         boardState.forEach(function (row, rownum) {
-            row.forEach(function (cardInRow) {
+            row["cards"].forEach(function (cardInRow) {
                 var newCard = builder.buildCard(templates.baseCard, cardInRow);
 
                 if (cardInRow["owner"] === "me") {


### PR DESCRIPTION
Allows cards to have the `:add-power` attribute, modifying cards upon play (if played with a `:target`).
I thought about creating an attribute called `:abilities` and putting all its abilities inside it. Right now we only have one ability so it seemed unpractical.

This resolves #75 and outdates #102 (since I needed those commits to check the `api` without doing the work twice)
