### PR TITLE
cleaner api/create-game

### DIFF
--- a/backend/src/api/base.clj
+++ b/backend/src/api/base.clj
@@ -21,22 +21,29 @@
             (get-game game-id player))
           {:error messages/out-of-turn})))
 
+(defn create-empty-game
+  "Creates a new instance of a game"
+  [& ini-config]
+  (let [game-id (persistence/next-id)]
+    (persistence/save-game
+      (assoc (create-game/new-game (first ini-config))
+             :game-id game-id))
+    game-id))
+
 (defn add-player
   "Adds a player to a game"
-  ([game-id] (add-player game-id {}))
-  ([game-id ini-config]
+  [game-id]
   (let [saved-game (persistence/fetch-game game-id)
         players-connected (count (:player-ids saved-game))]
     (if (> players-connected 1)
       {:error messages/too-many-players}
       (let [game-state (persistence/save-game
-                   (generators/player-uuid
-                     (or
-                       saved-game
-                       (assoc (create-game/new-game ini-config) :game-id game-id))))]
-        (get-game game-id (last (:player-ids game-state))))))))
+                         (generators/player-uuid
+                           saved-game))]
+        (get-game game-id (last (:player-ids game-state)))))))
 
 (defn create-game
-  "Creates a new instance of a game"
-  ([] (create-game {}))
-  ([ini-config] (add-player (persistence/next-id) ini-config)))
+  "Creates a new instance of a game with a player"
+  [& ini-config]
+  (-> (create-empty-game (first ini-config))
+      (add-player)))

--- a/backend/src/api/base.clj
+++ b/backend/src/api/base.clj
@@ -21,12 +21,12 @@
             (get-game game-id player))
           {:error messages/out-of-turn})))
 
-(defn create-empty-game
+(defn ^:private create-empty-game
   "Creates a new instance of a game"
-  [& ini-config]
+  [ini-config]
   (let [game-id (persistence/next-id)]
     (persistence/save-game
-      (assoc (create-game/new-game (first ini-config))
+      (assoc (create-game/new-game ini-config)
              :game-id game-id))
     game-id))
 
@@ -44,6 +44,7 @@
 
 (defn create-game
   "Creates a new instance of a game with a player"
-  [& ini-config]
-  (-> (create-empty-game (first ini-config))
-      (add-player)))
+  ([] (create-game {}))
+  ([ini-config]
+   (-> (create-empty-game ini-config)
+       (add-player))))


### PR DESCRIPTION
Resolves #101 though not with the exact names as in the issue.

- `create-empty-game`: Initialize a player-less game, with default configs.
- `add-player`: add a player to a game.
- `create-game`: Call the first two functions in order, this will be the new entry point for game creation in the API.


This way, only `api/base.clj` had to be changed.