### PR TITLE
Travis does not run E2E tests for develop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ jobs:
               - docker-compose run backend lein test
               - docker-compose run frontend yarn test
         - stage: End-to-End Tests
+          if: branch = master
           script:
               - docker-compose run frontend yarn install # Prepare modules
               - docker-compose -f docker-compose.yml -f docker-compose.e2e.yml run e2e test-delayed


### PR DESCRIPTION
Travis now should only run the e2e tests and require them to pass for merges to master.