### PR TITLE
Improved Mocking to more closely mimic reality

### DIFF
--- a/backend/src/api/base.clj
+++ b/backend/src/api/base.clj
@@ -51,6 +51,7 @@
                                   second-uuid]})
                   (assoc :game-id (:game-id lobby))
                   persistence/save-game
+                  :game-id
                   (get-game second-uuid))))))
 
 (defn create-game

--- a/backend/test/api/base_test.clj
+++ b/backend/test/api/base_test.clj
@@ -9,7 +9,7 @@
 (ctest/use-fixtures :each mocking/mock-persistence)
 
 (defexpect game-creation
-  (expect 0 (:game-id (base/create-game)))
+  (expect number? (:game-id (base/create-game)))
   (expect messages/no-opp (:status (base/create-game)))
   (expect nil (:player-ids (base/create-game)))
   (expect true (contains? (base/create-game) :player-id)))
@@ -17,7 +17,7 @@
 (defexpect join-game
 
   (let [joined-game (-> (base/create-game) :game-id base/add-player)]
-    (expect 0 (:game-id joined-game))
+    (expect number? (:game-id joined-game))
     (expect (count hands/default-hand)
             (count (filter
                      #(= "me" (:owner %))

--- a/backend/test/api/base_test.clj
+++ b/backend/test/api/base_test.clj
@@ -10,6 +10,9 @@
 
 (defexpect game-creation
   (expect number? (:game-id (base/create-game)))
+  (expect false (=
+                 (:game-id (base/create-game))
+                 (:game-id (base/create-game))))
   (expect messages/no-opp (:status (base/create-game)))
   (expect nil (:player-ids (base/create-game)))
   (expect true (contains? (base/create-game) :player-id)))

--- a/backend/test/mocking.clj
+++ b/backend/test/mocking.clj
@@ -1,15 +1,25 @@
 (ns mocking
   (:require [persistence.persistence :as persistence]))
 
-(def mock-game (atom nil))
+(def mock-game (atom {}))
+
+(def mock-id (atom 0))
 
 (defn mock-persistence
   [tests]
     (with-redefs
-      [persistence/next-id (constantly 0)
-       persistence/save-game (fn [a]
-                               (reset! mock-game a))
-       persistence/fetch-game (fn [x] 
-                                @mock-game)]
-      (tests))
-    (reset! mock-game nil))
+      [persistence/next-id (fn []
+                             (do
+                               (reset! mock-id (inc @mock-id))
+                               @mock-id))
+       persistence/save-game (fn [game]
+                               (reset!
+                                 mock-game
+                                 (assoc
+                                   @mock-game
+                                   {:game-id (:game-id game)}
+                                   game))
+                               game)
+       persistence/fetch-game (fn [id]
+                                (@mock-game {:game-id id}))]
+      (tests)))


### PR DESCRIPTION
This resolves #135.

Mocking now stores multiple games so we can unit test just as we would with the database but without firing up Redis.

This also helped detect 2 badly-defined tests and even caught a deadly bug in `add-player`!