### PR TITLE
show card-pow when in row

### DIFF
--- a/backend/src/api/player_view_functions.clj
+++ b/backend/src/api/player_view_functions.clj
@@ -6,10 +6,18 @@
   "Returns cards as seen by a player"
   [game-state player-id]
   (vec (map
-         #(if (= (:owner %) player-id)
-            (assoc % :owner "me")
-            {:location (:location %)
-             :owner "opp"})
+         #(cond
+           (= (:owner %) player-id)
+           (assoc % :owner "me")
+
+           (= (get-in % [:location 0]) :row)
+           {:power (:power %)
+            :location (:location %)
+            :owner "opp"}
+
+           :else
+           {:location (:location %)
+            :owner "opp"})
          (:cards game-state))))
 
 (defn get-rows

--- a/backend/test/api/player_view_functions_test.clj
+++ b/backend/test/api/player_view_functions_test.clj
@@ -8,7 +8,7 @@
   ; Gives cards as seen by a player
   (expect
     [{:location [:hand] :owner "opp"}
-     {:location [:row 0] :owner "opp"}
+     {:power -1 :location [:row 0] :owner "opp"}
      {:power 1 :attr "kill" :location [:hand] :owner "me"}
      {:power 100 :location [:row 1] :owner "me"}]
     (functions/get-cards {:cards [{:power 99 :location [:hand] :owner "opp_name"}

--- a/frontend/src/config/config.js
+++ b/frontend/src/config/config.js
@@ -18,7 +18,7 @@ try {
             frontend: "frontend:8880",
             backend: "backend:3000"
         }
-    }
+    };
 }
 
 module.exports = Object.assign(config, servers);


### PR DESCRIPTION
**Description**

Resolves a Bug: Api was not sending the power of opponent's card already played.

(also adds a missed semicolon on another file I found recently)

**Issues Resolved**

Not created but reported on Discord by @pernilsalat 

**Details**

I messed up when creating the test, since I did not take into account that cards on rows should always show their power.

**Hotspots**

Should we create some other test?
