### PR TITLE
Abilities to fe

### DIFF
--- a/backend/src/api/player_view_functions.clj
+++ b/backend/src/api/player_view_functions.clj
@@ -6,18 +6,27 @@
   "Returns cards as seen by a player"
   [game-state player-id]
   (vec (map
-         #(cond
-           (= (:owner %) player-id)
-           (assoc % :owner "me")
+         #(if (= (:owner %) player-id)
 
-           (= (get-in % [:location 0]) :row)
-           {:power (:power %)
-            :location (:location %)
-            :owner "opp"}
+            (if (and (contains? % :ability) (= (get-in % [:location 0]) :row))
+              (merge 
+                {:power (:power %)
+                 :location (:location %)
+                 :owner "me"}
+                ((:ability %)))
 
-           :else
-           {:location (:location %)
-            :owner "opp"})
+              {:power (:power %)
+               :location (:location %)
+               :owner "me"})
+
+            (if (= (get-in % [:location 0]) :row)
+              {:power (:power %)
+               :location (:location %)
+               :owner "opp"}
+
+              {:location (:location %)
+               :owner "opp"}))
+
          (:cards game-state))))
 
 (defn get-rows

--- a/backend/src/api/player_view_functions.clj
+++ b/backend/src/api/player_view_functions.clj
@@ -8,7 +8,7 @@
   (vec (map
          #(if (= (:owner %) player-id)
 
-            (if (and (contains? % :ability) (= (get-in % [:location 0]) :row))
+            (if (and (contains? % :ability) (= (get-in % [:location 0]) :hand))
               (merge 
                 {:power (:power %)
                  :location (:location %)

--- a/backend/src/rules/abilities.clj
+++ b/backend/src/rules/abilities.clj
@@ -4,10 +4,12 @@
   "Creates the ability function"
   [increase]
   (fn    
-;    "Alters a cards' power, by adding the a defined value to it.
-;    This power may be negative, resulting in a decrease"
-    [game-state target]
-    (update-in
-      game-state
-      [:cards target :power]
-      #(+ % increase))))
+;   "Alters a cards' power, by adding the a defined value to it.
+;   This power may be negative, resulting in a decrease"
+    ([game-state target]
+     (update-in
+       game-state
+       [:cards target :power]
+       #(+ % increase)))
+     ([])
+      {:description (str "Enhance " increase) :target 1}))

--- a/backend/src/rules/abilities.clj
+++ b/backend/src/rules/abilities.clj
@@ -11,5 +11,5 @@
        game-state
        [:cards target :power]
        #(+ % increase)))
-     ([])
-      {:description (str "Enhance " increase) :target 1}))
+     ([]
+      {:description (str "Enhance " increase) :target 1})))

--- a/backend/test/api/player_view_functions_test.clj
+++ b/backend/test/api/player_view_functions_test.clj
@@ -1,6 +1,7 @@
 (ns api.player-view-functions-test
   (:require [expectations.clojure.test :refer :all]
             [api.player-view-functions :as functions]
+            [rules.abilities :as ability]
             [configs.messages :as messages]))
 
 (defexpect get-cards
@@ -9,13 +10,27 @@
   (expect
     [{:location [:hand] :owner "opp"}
      {:power -1 :location [:row 0] :owner "opp"}
-     {:power 1 :attr "kill" :location [:hand] :owner "me"}
+     {:power 1 :location [:hand] :owner "me"}
      {:power 100 :location [:row 1] :owner "me"}]
     (functions/get-cards {:cards [{:power 99 :location [:hand] :owner "opp_name"}
                                   {:power -1 :location [:row 0] :owner "opp_name" :secret-attr "who knows?"}
-                                  {:power 1 :attr "kill" :location [:hand] :owner "me_name"}
+                                  {:power 1 :internal-attr "kill" :location [:hand] :owner "me_name"}
                                   {:power 100 :location [:row 1] :owner "me_name"}]}
-                        "me_name")))
+                        "me_name"))
+
+  ; Correctly returns cards with abilities
+  (expect
+    [{:power 1 :location [:hand] :owner "me" :description "Enhance 100" :target 1}
+     {:power 17 :location [:hand] :owner "me" :description "Enhance -1" :target 1}
+     {:location [:hand] :owner "opp"}
+     {:power -20 :location [:row 0] :owner "me"}
+     {:power 999 :location [:row 1] :owner "opp"}]
+    (functions/get-cards {:cards [{:power 1 :location [:hand] :owner "I" :ability (ability/add-power 100)}
+                                  {:power 17 :location [:hand] :owner "I" :ability (ability/add-power -1)}
+                                  {:power 17 :location [:hand] :owner "U" :ability (ability/add-power -1)}
+                                  {:power -20 :location [:row 0] :owner "I" :ability (ability/add-power 76)}
+                                  {:power 999 :location [:row 1] :owner "U" :ability (ability/add-power 22)}]}
+                        "I")))
 
 (defexpect get-rows
 

--- a/backend/test/rules/abilities_test.clj
+++ b/backend/test/rules/abilities_test.clj
@@ -18,7 +18,7 @@
 
   ; Returns info
   (expect
-    {:ability "Enhance 99" :target 1}
+    {:description "Enhance 99" :target 1}
     ((ability/add-power 99)))
 
    (expect

--- a/backend/test/rules/abilities_test.clj
+++ b/backend/test/rules/abilities_test.clj
@@ -14,5 +14,13 @@
   (expect
     -10
     (get-in ((ability/add-power -13) {:cards [{}{:power 3}]} 1)
-            [:cards 1 :power])))
+            [:cards 1 :power]))
 
+  ; Returns info
+  (expect
+    {:ability "Enhance 99" :target 1}
+    ((ability/add-power 99)))
+
+   expect
+    {:description "Enhance -1" :target 1}
+    ((ability/add-power -1)))

--- a/backend/test/rules/abilities_test.clj
+++ b/backend/test/rules/abilities_test.clj
@@ -21,6 +21,6 @@
     {:ability "Enhance 99" :target 1}
     ((ability/add-power 99)))
 
-   expect
+   (expect
     {:description "Enhance -1" :target 1}
-    ((ability/add-power -1)))
+    ((ability/add-power -1))))


### PR DESCRIPTION
**Description**

Backend responding API requests only gives relevant information about cards.

**Issues Resolved**

Resolves #154 

**Details**

All cards abilities (which are functions) must be created in a way that calling them without parameters gives the frontend relevant information. That's a `:description` and `:target`, as proposed by @kenan-rhoton on #154.

**Hotspots**

`(api.player_view_functions/get-cards` should be carefully reviewed. I tried to make it the most readable by dividing the 4 possible scenarios regarding card's info that must be shown and write every time what should be send. An alternative would be abuse `(merge` to avoid repetitions, but I felt that would be less redeable.


**Checklist for contribution requirements**
(I leave the checks for reviewers)

- [ ] The tests pass
- [ ] The code has tests
- [ ] The tests are well-designed
- [ ] The code is readable
- [ ] The code is well-organized
