### PR TITLE
Row types

### DIFF
--- a/backend/src/configs/rows.clj
+++ b/backend/src/configs/rows.clj
@@ -1,5 +1,5 @@
 (ns configs.rows)
 
 
-(def default-limits
-  (vec (repeat 5 4)))
+(def default-rows
+  (vec (repeat 5 {:limit 4})))

--- a/backend/src/rules/abilities.clj
+++ b/backend/src/rules/abilities.clj
@@ -4,10 +4,27 @@
   "Creates the ability function"
   [increase]
   (fn    
-;    "Alters a cards' power, by adding the a defined value to it.
+;    "Alters a card's power, by adding the a defined value to it.
 ;    This power may be negative, resulting in a decrease"
     [game-state play]
     (update-in
       game-state
       [:cards (:target play) :power]
       #(+ % increase))))
+
+(defn type-add-power
+  "Creates the ability function"
+  [row-type increase]
+  (fn
+;    "When played in a row-type row,
+;    alters a its power, by adding the a defined value to it.
+;    This power may be negative, resulting in a decrease"
+    [game-state play]
+    (if (= (get-in game-state [:rows (:row-id play) :type])
+           row-type)
+      (update-in
+        game-state
+        [:cards (:card-id play) :power]
+        #(+ % increase))
+
+      game-state)))

--- a/backend/src/rules/abilities.clj
+++ b/backend/src/rules/abilities.clj
@@ -6,8 +6,8 @@
   (fn    
 ;    "Alters a cards' power, by adding the a defined value to it.
 ;    This power may be negative, resulting in a decrease"
-    [game-state target]
+    [game-state play]
     (update-in
       game-state
-      [:cards target :power]
+      [:cards (:target play) :power]
       #(+ % increase))))

--- a/backend/src/rules/create_game.clj
+++ b/backend/src/rules/create_game.clj
@@ -19,9 +19,6 @@
       :cards (let [hands (:hands ini-config hands/default-hands)]
                (vec (concat (locate-in-hand (first hands) (first player-ids))
                             (locate-in-hand (second hands) (second player-ids)))))
-      :rows (vec (reduce
-                   #(concat %1 [{:limit %2}])
-                   []
-                   (:limits ini-config rows/default-limits)))
+      :rows (:rows ini-config rows/default-rows)
       :next-play {} 
    })))

--- a/backend/src/rules/play_card.clj
+++ b/backend/src/rules/play_card.clj
@@ -12,7 +12,7 @@
   [game-state play]
   (let [ability (get-in game-state [:cards (:card-id play) :ability])]
     (if (some? ability)
-      (ability game-state (:target play))
+      (ability game-state play)
       game-state)))
 
 (defn ^:private apply-all-plays

--- a/backend/test/api/player_view_functions_test.clj
+++ b/backend/test/api/player_view_functions_test.clj
@@ -22,13 +22,13 @@
   ; Gives rows with scores
   (expect
     [{:limit 1 :scores [0 0]}
-     {:limit 4 :scores [1 2]}
+     {:limit 4 :type "annoyer" :scores [1 2]}
      {:scores [12 0]}]
     (functions/get-rows {:cards [{:power 1 :location [:row 1] :owner "I"}
                                  {:power 2 :location [:row 1] :owner "U"}
                                  {:power 4 :location [:row 2] :owner "I"}
                                  {:power 8 :location [:row 2] :owner "I"}]
-                         :rows [{:limit 1}{:limit 4}{}]
+                         :rows [{:limit 1}{:limit 4 :type "annoyer"}{}]
                          :player-ids ["I" "U"]}
                         "I")))
 

--- a/backend/test/rules/abilities_test.clj
+++ b/backend/test/rules/abilities_test.clj
@@ -7,12 +7,12 @@
   ; Adds power
   (expect
     7
-    (get-in ((ability/add-power 5) {:cards [{:power 2}]} 0)
+    (get-in ((ability/add-power 5) {:cards [{:power 2}]} {:target 0})
             [:cards 0 :power]))
 
   ; Removes power
   (expect
     -10
-    (get-in ((ability/add-power -13) {:cards [{}{:power 3}]} 1)
+    (get-in ((ability/add-power -13) {:cards [{}{:power 3}]} {:target 1 :card-id 91 :something-else "whatever"})
             [:cards 1 :power])))
 

--- a/backend/test/rules/abilities_test.clj
+++ b/backend/test/rules/abilities_test.clj
@@ -16,3 +16,25 @@
     (get-in ((ability/add-power -13) {:cards [{}{:power 3}]} {:target 1 :card-id 91 :something-else "whatever"})
             [:cards 1 :power])))
 
+(defexpect type-add-power
+
+  ; Does nothing when shouldn't
+  (expect
+    42
+    (get-in ((ability/type-add-power "invi" 10) {:cards [{:power 42}] :rows [{}]} {:row-id 0 :card-id 0})
+            [:cards 0 :power]))
+  (expect
+    99
+    (get-in ((ability/type-add-power "invi" 10) {:cards [{}{:power 99}] :rows [{}{:type "type-0"}]} {:row-id 1 :card-id 1})
+            [:cards 1 :power]))
+  
+  ; Adds power when should
+  (expect
+    52
+    (get-in ((ability/type-add-power "invi" 10) {:cards [{:power 42}] :rows [{:type "invi"}]} {:row-id 0 :card-id 0})
+            [:cards 0 :power]))
+
+  (expect
+    -2
+    (get-in ((ability/type-add-power "vivi" -3) {:cards [{:power 42} {:power 1}] :rows [{}{}{:type "vivi"}]} {:row-id 2 :card-id 1})
+            [:cards 1 :power])))

--- a/backend/test/rules/create_game_test.clj
+++ b/backend/test/rules/create_game_test.clj
@@ -49,8 +49,8 @@
     (:cards (create-game/new-game {:hands [[{:p 0}][{:attr 12 :sometext ""}]]})))
   
   (expect
-     [{:limit 0} {:limit 3}]
-    (:rows (create-game/new-game {:limits [0 3]})))
+    [{:limit 92} {} {:type "yabidi"}]
+    (:rows (create-game/new-game {:rows [{:limit 92} {} {:type "yabidi"}]})))
   
   ; Game uses default config
   (expect
@@ -58,8 +58,8 @@
     (map #(apply dissoc % [:location :owner]) (:cards (create-game/new-game))))
   
   (expect
-    rows/default-limits
-    (vec (map :limit (:rows (create-game/new-game)))))
+    rows/default-rows
+    (:rows (create-game/new-game)))
   
   (expect
     player-ids/default-player-ids


### PR DESCRIPTION
**Description**

New ability created: Now cards can have an ability that makes their power change when played on specific rows.

Rows can have a `:type` and this ability checks if the card had been played on a row of the appropriate type.

Also, I changed `(add-power` so all abilities recieve `game-state` and `play`.

**Issues Resolved**

Resolves #150 

**Hotspots**

The merge with PR #162 might be a bit messy (considereng how few files them both change).

`(rules.abilities/type-add-power` is probably what's most relevant.

**Checklist for contribution requirements**

- [ ] The tests pass
- [ ] The code has tests
- [ ] The tests are well-designed
- [ ] The code is readable
- [ ] The code is well-organized
- [x] Any rule changed or included is also on the Manual
