### PR TITLE
Row types

### DIFF
--- a/backend/src/api/player_view_functions.clj
+++ b/backend/src/api/player_view_functions.clj
@@ -6,18 +6,27 @@
   "Returns cards as seen by a player"
   [game-state player-id]
   (vec (map
-         #(cond
-           (= (:owner %) player-id)
-           (assoc % :owner "me")
+         #(if (= (:owner %) player-id)
 
-           (= (get-in % [:location 0]) :row)
-           {:power (:power %)
-            :location (:location %)
-            :owner "opp"}
+            (if (and (contains? % :ability) (= (get-in % [:location 0]) :row))
+              (merge 
+                {:power (:power %)
+                 :location (:location %)
+                 :owner "me"}
+                ((:ability %)))
 
-           :else
-           {:location (:location %)
-            :owner "opp"})
+              {:power (:power %)
+               :location (:location %)
+               :owner "me"})
+
+            (if (= (get-in % [:location 0]) :row)
+              {:power (:power %)
+               :location (:location %)
+               :owner "opp"}
+
+              {:location (:location %)
+               :owner "opp"}))
+
          (:cards game-state))))
 
 (defn get-rows

--- a/backend/src/api/player_view_functions.clj
+++ b/backend/src/api/player_view_functions.clj
@@ -8,7 +8,7 @@
   (vec (map
          #(if (= (:owner %) player-id)
 
-            (if (and (contains? % :ability) (= (get-in % [:location 0]) :row))
+            (if (and (contains? % :ability) (= (get-in % [:location 0]) :hand))
               (merge 
                 {:power (:power %)
                  :location (:location %)

--- a/backend/src/api/player_view_functions.clj
+++ b/backend/src/api/player_view_functions.clj
@@ -14,10 +14,8 @@
   (vec (map
          #(cond
             (and (= (:owner %) player-id)
-                 (contains? % :ability)
                  (= (get-in % [:location 0]) :hand))
-            (merge (partial-card % [:power :location] "me")
-                   ((:ability %)))
+            (partial-card % [:power :location :description :target] "me")
 
             (= (:owner %) player-id)
             (partial-card % [:power :location] "me")

--- a/backend/src/configs/hands.clj
+++ b/backend/src/configs/hands.clj
@@ -5,12 +5,12 @@
   "Default hand (can't be empty)"
   [{:power 8}
    {:power 7}
-   {:power 6 :ability (ability/type-add-power "overpower" 1)}
-   {:power 5 :ability (ability/type-add-power "overpower" 3)}
-   {:power 6 :ability (ability/add-power 1)}
-   {:power 6 :ability (ability/add-power -1)}
-   {:power 4 :ability (ability/add-power 2)}
-   {:power 4 :ability (ability/add-power -2)}])
+   (merge {:power 6} (ability/type-add-power "overpower" 1))
+   (merge {:power 5} (ability/type-add-power "overpower" 3))
+   (merge {:power 6} (ability/add-power 1))
+   (merge {:power 6} (ability/add-power -1))
+   (merge {:power 4} (ability/add-power 2))
+   (merge {:power 4} (ability/add-power -2))])
 
 (def default-hands
   "Default hands"

--- a/backend/src/configs/hands.clj
+++ b/backend/src/configs/hands.clj
@@ -3,10 +3,10 @@
 
 (def default-hand
   "Default hand (can't be empty)"
-  [{:power 10}
-   {:power 9}
-   {:power 8}
+  [{:power 8}
    {:power 7}
+   {:power 6 :ability (ability/type-add-power "overpower" 1)}
+   {:power 5 :ability (ability/type-add-power "overpower" 3)}
    {:power 6 :ability (ability/add-power 1)}
    {:power 6 :ability (ability/add-power -1)}
    {:power 4 :ability (ability/add-power 2)}

--- a/backend/src/configs/rows.clj
+++ b/backend/src/configs/rows.clj
@@ -2,4 +2,8 @@
 
 
 (def default-rows
-  (vec (repeat 5 {:limit 4})))
+  [{:limit 4}
+   {:limit 4}
+   {:limit 4 :type "overpower"}
+   {:limit 4}
+   {:limit 4}])

--- a/backend/src/configs/rows.clj
+++ b/backend/src/configs/rows.clj
@@ -2,8 +2,8 @@
 
 
 (def default-rows
-  [{:limit 4}
-   {:limit 4}
-   {:limit 4 :type "overpower"}
-   {:limit 4}
-   {:limit 4}])
+  [{:limit 3 :type "overpower"}
+   {:limit 3}
+   {:limit 3}
+   {:limit 3}
+   {:limit 3}])

--- a/backend/src/configs/rows.clj
+++ b/backend/src/configs/rows.clj
@@ -1,5 +1,5 @@
 (ns configs.rows)
 
 
-(def default-limits
-  (vec (repeat 5 4)))
+(def default-rows
+  (vec (repeat 5 {:limit 4})))

--- a/backend/src/rules/abilities.clj
+++ b/backend/src/rules/abilities.clj
@@ -12,4 +12,7 @@
        [:cards target :power]
        #(+ % increase)))
      ([]
-      {:description (str "Enhance " increase) :target 1})))
+      {:description (if (neg? increase)
+                      (str "Weaken " (- increase))
+                      (str "Enhance " increase))
+       :target 1})))

--- a/backend/src/rules/abilities.clj
+++ b/backend/src/rules/abilities.clj
@@ -3,28 +3,29 @@
 (defn add-power
   "Creates the ability function"
   [increase]
-  (fn    
-;   "Alters a cards' power, by adding the a defined value to it.
-;   This power may be negative, resulting in a decrease"
-    ([game-state play]
+  {:ability
+   (fn    
+;    "Alters a cards' power, by adding the a defined value to it.
+;    This power may be negative, resulting in a decrease"
+     [game-state play]
      (update-in
        game-state
        [:cards (:target play) :power]
        #(+ % increase)))
-     ([]
-      {:description (if (neg? increase)
-                      (str "Weaken " (- increase))
-                      (str "Enhance " increase))
-       :target 1})))
+   :description (if (neg? increase)
+                    (str "Weaken " (- increase))
+                    (str "Enhance " increase))
+   :target 1})
 
 (defn type-add-power
   "Creates the ability function"
   [row-type increase]
-  (fn
+  {:ability
+   (fn
 ;    "When played in a row-type row,
 ;    alters a its power, by adding the a defined value to it.
 ;    This power may be negative, resulting in a decrease"
-    ([game-state play]
+     [game-state play]
      (if (= (get-in game-state [:rows (:row-id play) :type])
             row-type)
        (update-in
@@ -33,7 +34,6 @@
          #(+ % increase))
 
        game-state))
-    ([]
-     {:description (if (neg? increase)
-                     (str "Weaken " (- increase) " on " type)
-                     (str "Enhance " increase "on " type))})))
+   :description (if (neg? increase)
+                    (str "Weaken " (- increase) " on " row-type)
+                    (str "Enhance " increase " on " row-type))})

--- a/backend/src/rules/abilities.clj
+++ b/backend/src/rules/abilities.clj
@@ -4,10 +4,27 @@
   "Creates the ability function"
   [increase]
   (fn    
-;    "Alters a cards' power, by adding the a defined value to it.
+;    "Alters a card's power, by adding the a defined value to it.
 ;    This power may be negative, resulting in a decrease"
     [game-state play]
     (update-in
       game-state
       [:cards (:target play) :power]
       #(+ % increase))))
+
+(defn type-add-power
+  "Creates the ability function"
+  [row-type increase]
+  (fn
+;    "When played in a row-type row,
+;    alters a its power, by adding the a defined value to it.
+;    This power may be negative, resulting in a decrease"
+    [game-state play]
+    (if (= (get-in game-state [:rows (:row-id play) :type])
+           row-type)
+      (update-in
+        game-state
+        [:cards (:card-id play) :power]
+        #(+ % increase))
+
+      game-state)))

--- a/backend/src/rules/abilities.clj
+++ b/backend/src/rules/abilities.clj
@@ -4,10 +4,12 @@
   "Creates the ability function"
   [increase]
   (fn    
-;    "Alters a cards' power, by adding the a defined value to it.
-;    This power may be negative, resulting in a decrease"
-    [game-state target]
-    (update-in
-      game-state
-      [:cards target :power]
-      #(+ % increase))))
+;   "Alters a cards' power, by adding the a defined value to it.
+;   This power may be negative, resulting in a decrease"
+    ([game-state target]
+     (update-in
+       game-state
+       [:cards target :power]
+       #(+ % increase)))
+     ([])
+      {:description (str "Enhance " increase) :target 1}))

--- a/backend/src/rules/abilities.clj
+++ b/backend/src/rules/abilities.clj
@@ -11,5 +11,5 @@
        game-state
        [:cards target :power]
        #(+ % increase)))
-     ([])
-      {:description (str "Enhance " increase) :target 1}))
+     ([]
+      {:description (str "Enhance " increase) :target 1})))

--- a/backend/src/rules/abilities.clj
+++ b/backend/src/rules/abilities.clj
@@ -6,8 +6,8 @@
   (fn    
 ;    "Alters a cards' power, by adding the a defined value to it.
 ;    This power may be negative, resulting in a decrease"
-    [game-state target]
+    [game-state play]
     (update-in
       game-state
-      [:cards target :power]
+      [:cards (:target play) :power]
       #(+ % increase))))

--- a/backend/src/rules/create_game.clj
+++ b/backend/src/rules/create_game.clj
@@ -19,9 +19,6 @@
       :cards (let [hands (:hands ini-config hands/default-hands)]
                (vec (concat (locate-in-hand (first hands) (first player-ids))
                             (locate-in-hand (second hands) (second player-ids)))))
-      :rows (vec (reduce
-                   #(concat %1 [{:limit %2}])
-                   []
-                   (:limits ini-config rows/default-limits)))
+      :rows (:rows ini-config rows/default-rows)
       :next-play {} 
    })))

--- a/backend/src/rules/play_card.clj
+++ b/backend/src/rules/play_card.clj
@@ -37,9 +37,7 @@
 
 (defn ^:private requires-target?
   [game-state card-id]
-  (let [card-ability (get-in game-state [:cards card-id :ability])]
-        (and (not (nil? card-ability))
-             (contains? (card-ability) :target))))
+  (contains? (get-in game-state [:cards card-id]) :target))
 
 (defn play-card
   "Takes a playing of a card from hand onto a game row and makes it wait until both players had played"

--- a/backend/src/rules/play_card.clj
+++ b/backend/src/rules/play_card.clj
@@ -12,7 +12,7 @@
   [game-state play]
   (let [ability (get-in game-state [:cards (:card-id play) :ability])]
     (if (some? ability)
-      (ability game-state (:target play))
+      (ability game-state play)
       game-state)))
 
 (defn ^:private apply-all-plays

--- a/backend/test/api/player_view_functions_test.clj
+++ b/backend/test/api/player_view_functions_test.clj
@@ -25,11 +25,11 @@
      {:location [:hand] :owner "opp"}
      {:power -20 :location [:row 0] :owner "me"}
      {:power 999 :location [:row 1] :owner "opp"}]
-    (functions/get-cards {:cards [{:power 1 :location [:hand] :owner "I" :ability (ability/add-power 100)}
-                                  {:power 17 :location [:hand] :owner "I" :ability (ability/add-power -1)}
-                                  {:power 17 :location [:hand] :owner "U" :ability (ability/add-power -1)}
-                                  {:power -20 :location [:row 0] :owner "I" :ability (ability/add-power 76)}
-                                  {:power 999 :location [:row 1] :owner "U" :ability (ability/add-power 22)}]}
+    (functions/get-cards {:cards [(merge {:power 1 :location [:hand] :owner "I"} (ability/add-power 100))
+                                  (merge {:power 17 :location [:hand] :owner "I"} (ability/add-power -1))
+                                  (merge {:power 17 :location [:hand] :owner "U"} (ability/add-power -1))
+                                  (merge {:power -20 :location [:row 0] :owner "I"} (ability/add-power 76))
+                                  (merge {:power 999 :location [:row 1] :owner "U"} (ability/add-power 22))]}
                         "I")))
 
 (defexpect get-rows

--- a/backend/test/api/player_view_functions_test.clj
+++ b/backend/test/api/player_view_functions_test.clj
@@ -22,13 +22,13 @@
   ; Gives rows with scores
   (expect
     [{:limit 1 :scores [0 0]}
-     {:limit 4 :scores [1 2]}
+     {:limit 4 :type "annoyer" :scores [1 2]}
      {:scores [12 0]}]
     (functions/get-rows {:cards [{:power 1 :location [:row 1] :owner "I"}
                                  {:power 2 :location [:row 1] :owner "U"}
                                  {:power 4 :location [:row 2] :owner "I"}
                                  {:power 8 :location [:row 2] :owner "I"}]
-                         :rows [{:limit 1}{:limit 4}{}]
+                         :rows [{:limit 1}{:limit 4 :type "annoyer"}{}]
                          :player-ids ["I" "U"]}
                         "I")))
 

--- a/backend/test/api/player_view_functions_test.clj
+++ b/backend/test/api/player_view_functions_test.clj
@@ -1,6 +1,7 @@
 (ns api.player-view-functions-test
   (:require [expectations.clojure.test :refer :all]
             [api.player-view-functions :as functions]
+            [rules.abilities :as ability]
             [configs.messages :as messages]))
 
 (defexpect get-cards
@@ -9,13 +10,27 @@
   (expect
     [{:location [:hand] :owner "opp"}
      {:power -1 :location [:row 0] :owner "opp"}
-     {:power 1 :attr "kill" :location [:hand] :owner "me"}
+     {:power 1 :location [:hand] :owner "me"}
      {:power 100 :location [:row 1] :owner "me"}]
     (functions/get-cards {:cards [{:power 99 :location [:hand] :owner "opp_name"}
                                   {:power -1 :location [:row 0] :owner "opp_name" :secret-attr "who knows?"}
-                                  {:power 1 :attr "kill" :location [:hand] :owner "me_name"}
+                                  {:power 1 :internal-attr "kill" :location [:hand] :owner "me_name"}
                                   {:power 100 :location [:row 1] :owner "me_name"}]}
-                        "me_name")))
+                        "me_name"))
+
+  ; Correctly returns cards with abilities
+  (expect
+    [{:power 1 :location [:hand] :owner "me" :description "Enhance 100" :target 1}
+     {:power 17 :location [:hand] :owner "me" :description "Enhance -1" :target 1}
+     {:location [:hand] :owner "opp"}
+     {:power -20 :location [:row 0] :owner "me"}
+     {:power 999 :location [:row 1] :owner "opp"}]
+    (functions/get-cards {:cards [{:power 1 :location [:hand] :owner "I" :ability (ability/add-power 100)}
+                                  {:power 17 :location [:hand] :owner "I" :ability (ability/add-power -1)}
+                                  {:power 17 :location [:hand] :owner "U" :ability (ability/add-power -1)}
+                                  {:power -20 :location [:row 0] :owner "I" :ability (ability/add-power 76)}
+                                  {:power 999 :location [:row 1] :owner "U" :ability (ability/add-power 22)}]}
+                        "I")))
 
 (defexpect get-rows
 

--- a/backend/test/api/player_view_functions_test.clj
+++ b/backend/test/api/player_view_functions_test.clj
@@ -21,7 +21,7 @@
   ; Correctly returns cards with abilities
   (expect
     [{:power 1 :location [:hand] :owner "me" :description "Enhance 100" :target 1}
-     {:power 17 :location [:hand] :owner "me" :description "Enhance -1" :target 1}
+     {:power 17 :location [:hand] :owner "me" :description "Weaken 1" :target 1}
      {:location [:hand] :owner "opp"}
      {:power -20 :location [:row 0] :owner "me"}
      {:power 999 :location [:row 1] :owner "opp"}]

--- a/backend/test/rules/abilities_test.clj
+++ b/backend/test/rules/abilities_test.clj
@@ -18,7 +18,7 @@
 
   ; Returns info
   (expect
-    {:ability "Enhance 99" :target 1}
+    {:description "Enhance 99" :target 1}
     ((ability/add-power 99)))
 
    (expect

--- a/backend/test/rules/abilities_test.clj
+++ b/backend/test/rules/abilities_test.clj
@@ -7,43 +7,59 @@
   ; Adds power
   (expect
     7
-    (get-in ((ability/add-power 5) {:cards [{:power 2}]} {:target 0})
+    (get-in ((:ability (ability/add-power 5)) {:cards [{:power 2}]} {:target 0})
             [:cards 0 :power]))
 
   ; Removes power
   (expect
     -10
-    (get-in ((ability/add-power -13) {:cards [{}{:power 3}]} {:target 1 :card-id 91 :something-else "whatever"})
+    (get-in ((:ability (ability/add-power -13)) {:cards [{}{:power 3}]} {:target 1 :card-id 91 :something-else "whatever"})
             [:cards 1 :power]))
   
   ; Returns info
   (expect
-    {:description "Enhance 99" :target 1}
-    ((ability/add-power 99)))
+    "Enhance 99"
+    (:description (ability/add-power 99)))
 
-   (expect
-    {:description "Weaken 1" :target 1}
-    ((ability/add-power -1))))
+  (expect
+    "Weaken 1"
+    (:description (ability/add-power -1)))
+  
+  (expect
+    1
+    (:target (ability/add-power 0))))
 
 (defexpect type-add-power
 
   ; Does nothing when shouldn't
   (expect
     42
-    (get-in ((ability/type-add-power "invi" 10) {:cards [{:power 42}] :rows [{}]} {:row-id 0 :card-id 0})
+    (get-in ((:ability (ability/type-add-power "invi" 10)) {:cards [{:power 42}] :rows [{}]} {:row-id 0 :card-id 0})
             [:cards 0 :power]))
   (expect
     99
-    (get-in ((ability/type-add-power "invi" 10) {:cards [{}{:power 99}] :rows [{}{:type "type-0"}]} {:row-id 1 :card-id 1})
+    (get-in ((:ability (ability/type-add-power "invi" 10)) {:cards [{}{:power 99}] :rows [{}{:type "type-0"}]} {:row-id 1 :card-id 1})
             [:cards 1 :power]))
   
   ; Adds power when should
   (expect
     52
-    (get-in ((ability/type-add-power "invi" 10) {:cards [{:power 42}] :rows [{:type "invi"}]} {:row-id 0 :card-id 0})
+    (get-in ((:ability (ability/type-add-power "invi" 10)) {:cards [{:power 42}] :rows [{:type "invi"}]} {:row-id 0 :card-id 0})
             [:cards 0 :power]))
 
   (expect
     -2
-    (get-in ((ability/type-add-power "vivi" -3) {:cards [{:power 42} {:power 1}] :rows [{}{}{:type "vivi"}]} {:row-id 2 :card-id 1})
-            [:cards 1 :power])))
+    (get-in ((:ability (ability/type-add-power "vivi" -3)) {:cards [{:power 42} {:power 1}] :rows [{}{}{:type "vivi"}]} {:row-id 2 :card-id 1})
+            [:cards 1 :power]))
+  
+  ; Returns info
+  (expect
+    "Enhance 7 on iris"
+    (:description (ability/type-add-power "iris" 7)))
+
+  (expect
+    "Weaken 3 on negat"
+    (:description (ability/type-add-power "negat" -3)))
+
+  (expect
+    (not (contains? (ability/type-add-power "notarget" 1) :target))))

--- a/backend/test/rules/abilities_test.clj
+++ b/backend/test/rules/abilities_test.clj
@@ -7,12 +7,12 @@
   ; Adds power
   (expect
     7
-    (get-in ((ability/add-power 5) {:cards [{:power 2}]} 0)
+    (get-in ((ability/add-power 5) {:cards [{:power 2}]} {:target 0})
             [:cards 0 :power]))
 
   ; Removes power
   (expect
     -10
-    (get-in ((ability/add-power -13) {:cards [{}{:power 3}]} 1)
+    (get-in ((ability/add-power -13) {:cards [{}{:power 3}]} {:target 1 :card-id 91 :something-else "whatever"})
             [:cards 1 :power])))
 

--- a/backend/test/rules/abilities_test.clj
+++ b/backend/test/rules/abilities_test.clj
@@ -22,5 +22,5 @@
     ((ability/add-power 99)))
 
    (expect
-    {:description "Enhance -1" :target 1}
+    {:description "Weaken 1" :target 1}
     ((ability/add-power -1))))

--- a/backend/test/rules/abilities_test.clj
+++ b/backend/test/rules/abilities_test.clj
@@ -16,3 +16,25 @@
     (get-in ((ability/add-power -13) {:cards [{}{:power 3}]} {:target 1 :card-id 91 :something-else "whatever"})
             [:cards 1 :power])))
 
+(defexpect type-add-power
+
+  ; Does nothing when shouldn't
+  (expect
+    42
+    (get-in ((ability/type-add-power "invi" 10) {:cards [{:power 42}] :rows [{}]} {:row-id 0 :card-id 0})
+            [:cards 0 :power]))
+  (expect
+    99
+    (get-in ((ability/type-add-power "invi" 10) {:cards [{}{:power 99}] :rows [{}{:type "type-0"}]} {:row-id 1 :card-id 1})
+            [:cards 1 :power]))
+  
+  ; Adds power when should
+  (expect
+    52
+    (get-in ((ability/type-add-power "invi" 10) {:cards [{:power 42}] :rows [{:type "invi"}]} {:row-id 0 :card-id 0})
+            [:cards 0 :power]))
+
+  (expect
+    -2
+    (get-in ((ability/type-add-power "vivi" -3) {:cards [{:power 42} {:power 1}] :rows [{}{}{:type "vivi"}]} {:row-id 2 :card-id 1})
+            [:cards 1 :power])))

--- a/backend/test/rules/abilities_test.clj
+++ b/backend/test/rules/abilities_test.clj
@@ -14,5 +14,13 @@
   (expect
     -10
     (get-in ((ability/add-power -13) {:cards [{}{:power 3}]} 1)
-            [:cards 1 :power])))
+            [:cards 1 :power]))
 
+  ; Returns info
+  (expect
+    {:ability "Enhance 99" :target 1}
+    ((ability/add-power 99)))
+
+   expect
+    {:description "Enhance -1" :target 1}
+    ((ability/add-power -1)))

--- a/backend/test/rules/abilities_test.clj
+++ b/backend/test/rules/abilities_test.clj
@@ -21,6 +21,6 @@
     {:ability "Enhance 99" :target 1}
     ((ability/add-power 99)))
 
-   expect
+   (expect
     {:description "Enhance -1" :target 1}
-    ((ability/add-power -1)))
+    ((ability/add-power -1))))

--- a/backend/test/rules/create_game_test.clj
+++ b/backend/test/rules/create_game_test.clj
@@ -49,8 +49,8 @@
     (:cards (create-game/new-game {:hands [[{:p 0}][{:attr 12 :sometext ""}]]})))
   
   (expect
-     [{:limit 0} {:limit 3}]
-    (:rows (create-game/new-game {:limits [0 3]})))
+    [{:limit 92} {} {:type "yabidi"}]
+    (:rows (create-game/new-game {:rows [{:limit 92} {} {:type "yabidi"}]})))
   
   ; Game uses default config
   (expect
@@ -58,8 +58,8 @@
     (map #(apply dissoc % [:location :owner]) (:cards (create-game/new-game))))
   
   (expect
-    rows/default-limits
-    (vec (map :limit (:rows (create-game/new-game)))))
+    rows/default-rows
+    (:rows (create-game/new-game)))
   
   (expect
     player-ids/default-player-ids

--- a/backend/test/rules/play_card_test.clj
+++ b/backend/test/rules/play_card_test.clj
@@ -4,7 +4,9 @@
             [rules.abilities :as ability]
             [configs.messages :as messages]))
 
-  (def game-state {:cards [{:power 0 :location [:hand]} {:power 10 :ability (ability/add-power -1)} {:power 100 :ability (ability/add-power -100)}]
+  (def game-state {:cards [{:power 0 :location [:hand]}
+                           (merge {:power 10} (ability/add-power -1))
+                           (merge {:power 100} (ability/add-power -100))]
                    :rows [{}{}{}{}]
                    :next-play {:p0 {:card-id 0 :row-id 0} :p1 {:card-id 1 :row-id 3 :target 2}}
                    :player-ids ["p0" "p1"]})
@@ -85,13 +87,13 @@
     {:error messages/need-target}
     (play-card/play-card {:next-play {}
                           :rows [{}]
-                          :cards [{:ability (ability/add-power 1) :owner "dumb"}]} "dumb" 0 0))
+                          :cards [{:target 1 :owner "dumb"}]} "dumb" 0 0))
 
   (expect
     {:error messages/invalid-target}
     (play-card/play-card {:next-play {}
                           :rows [{}]
-                          :cards [{:ability (ability/add-power -1) :owner "McCheaty"}{:location ["nowhere"]}]} "McCheaty" 0 0 1))
+                          :cards [{:target 1 :owner "McCheaty"}{:location ["nowhere"]}]} "McCheaty" 0 0 1))
   
   ; Saves next-play
   (expect
@@ -106,7 +108,7 @@
     (:next-play
       (play-card/play-card {:next-play {}
                             :rows [{}{}{}{}]
-                            :cards [{:location [:row 0]}{}{:owner "p" :ability (ability/add-power 1)}]} "p" 2 3 0)))
+                            :cards [{:location [:row 0]}{}{:owner "p" :target 1}]} "p" 2 3 0)))
 
   (expect
     [{:owner "p"}]
@@ -118,7 +120,9 @@
 
   (let [new-game-state
         (play-card/play-card 
-          {:cards [{:power 0 :location [:hand] :owner "p0"} {:power 10 :ability (ability/add-power -1) :owner "p1"} {:power 100 :ability (ability/add-power -100)}]
+          {:cards [{:power 0 :location [:hand] :owner "p0"}
+                   (merge {:power 10 :owner "p1"} (ability/add-power -1))
+                   (merge {:power 100} (ability/add-power -100))]
            :rows [{}{}{}{}{}]
            :next-play {:p1 {:card-id 1 :row-id 3 :target 2}}}
           "p0" 0 0)]


### PR DESCRIPTION
**Description**

New ability created: Now cards can have an ability that makes their power change when played on specific rows.

Rows can have a `:type` and this ability checks if the card had been played on a row of the appropriate type.

Also, I changed `(add-power` so all abilities recieve `game-state` and `play`.

**Issues Resolved**

Resolves #150 

**Hotspots**

`(rules.abilities/type-add-power` is probably what's most relevant.

Still, I find it **very important** to double-check that we have all the tests we'd want to.

**Checklist for contribution requirements**

- [x] The tests pass
- [x] The code has tests
- [x] The tests are well-designed
- [ ] The code is readable
- [ ] The code is well-organized
- [x] Any rule changed or included is also on the Manual
